### PR TITLE
Allow globalized selectors to be curried

### DIFF
--- a/src/__tests__/globalizeSelectors-spec.js
+++ b/src/__tests__/globalizeSelectors-spec.js
@@ -1,4 +1,4 @@
-import { prop } from 'ramda'
+import { curry, prop } from 'ramda'
 
 import globalizeSelectors from '../globalizeSelectors'
 
@@ -8,25 +8,34 @@ describe('globalizeSelectors', () => {
       numbers: [2, 3, 4]
     }
   }
-
   const localState = prop('section')
-
-  const selectors = {
-    numbers: prop('numbers'),
-    numberAt: (index, state) => state.numbers[index]
-  }
-
-  const globalized = globalizeSelectors(localState, selectors)
+  const numbers = prop('numbers')
+  const numberAt = (index, state) => state.numbers[index]
+  const globalized = globalizeSelectors(localState, {
+    numbers,
+    numberAt,
+    curriedNumberAt: curry(numberAt)
+  })
 
   context('with a single-argument selector', () => {
-    test('allows the selector to work from the global state', () => {
+    it('allows the selector to work from the global state', () => {
       expect(globalized.numbers(globalState)).toEqual([2, 3, 4])
     })
   })
 
   context('with a multi-argument selector', () => {
-    test('allows the selector to work from the global state', () => {
-      expect(globalized.numberAt(1, globalState)).toEqual(3)
+    it('allows the selector to work from the global state', () => {
+      expect(globalized.numberAt(1, globalState)).toBe(3)
+    })
+  })
+
+  context('with a curried selector', () => {
+    it('allows the selector to work from the global state', () => {
+      expect(globalized.curriedNumberAt(2, globalState)).toBe(4)
+    })
+
+    it('can be called in a curried fashion', () => {
+      expect(globalized.curriedNumberAt(2)(globalState)).toBe(4)
     })
   })
 })

--- a/src/__tests__/globalizeSelectors-spec.js
+++ b/src/__tests__/globalizeSelectors-spec.js
@@ -18,23 +18,23 @@ describe('globalizeSelectors', () => {
   })
 
   context('with a single-argument selector', () => {
-    it('allows the selector to work from the global state', () => {
+    test('allows the selector to work from the global state', () => {
       expect(globalized.numbers(globalState)).toEqual([2, 3, 4])
     })
   })
 
   context('with a multi-argument selector', () => {
-    it('allows the selector to work from the global state', () => {
+    test('allows the selector to work from the global state', () => {
       expect(globalized.numberAt(1, globalState)).toBe(3)
     })
   })
 
   context('with a curried selector', () => {
-    it('allows the selector to work from the global state', () => {
+    test('the selector can be called normally', () => {
       expect(globalized.curriedNumberAt(2, globalState)).toBe(4)
     })
 
-    it('can be called in a curried fashion', () => {
+    test('the selector can be curried', () => {
       expect(globalized.curriedNumberAt(2)(globalState)).toBe(4)
     })
   })

--- a/src/globalizeSelectors.js
+++ b/src/globalizeSelectors.js
@@ -1,4 +1,4 @@
-import { adjust, map } from 'ramda'
+import { adjust, curryN, length, map } from 'ramda'
 
 /*
 Take a local state transform and an object containing selector functions.
@@ -22,8 +22,10 @@ argument, transforms that state into local state, and then calls the original,
 localized, selector.
 */
 
-const globalize = transform => selector => (...args) =>
-  selector(...adjust(transform, -1, args))
+const globalize = transform => selector =>
+  curryN(length(selector),
+    (...args) => selector(...adjust(transform, -1, args))
+  )
 
 export default (localStateTransform, selectors) =>
   map(globalize(localStateTransform), selectors)


### PR DESCRIPTION
The initial implementation of `globalizeSelectors` could wrap curried functions, but did not allow them to be called as curried functions.

* Add a new specs to ensure we can call curried selectors normally and as curried functions.
* Modify `globalizeSelectors` to explicitly curry the selectors with `curryN`.