### PR TITLE
Check for flux-standard-actions in reducers

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/codingzeal/zeal-redux-utils#readme",
   "dependencies": {
+    "flux-standard-action": "^1.0.0",
     "ramda": "^0.22.1"
   },
   "jest": {

--- a/src/__tests__/createReducer-spec.js
+++ b/src/__tests__/createReducer-spec.js
@@ -1,4 +1,4 @@
-import createReducer from '../createReducer'
+import createReducer, { NonStandardAction } from '../createReducer'
 
 describe('createReducer', () => {
   const mockHandler = jest.fn()
@@ -19,5 +19,13 @@ describe('createReducer', () => {
     reducer(state, action)
 
     expect(mockHandler).toBeCalledWith(state, action)
+  })
+
+  test('the reducer checks for flux standard actions', () => {
+    const invalidAction = {}
+
+    expect(
+      () => reducer(state, invalidAction)
+    ).toThrowError(NonStandardAction)
   })
 })

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -1,6 +1,29 @@
+import { isFSA } from 'flux-standard-action'
 import { identity, propOr } from 'ramda'
 
-export default function createReducer(initialState, handlers) {
-  return (state = initialState, action) =>
-    propOr(identity, action.type, handlers)(state, action)
+export class NonStandardAction {
+  constructor(action) {
+    this.action = action
+    this.message =
+      'attempting to handle an action that is not a flux-standard-action'
+    this.stack = (new Error()).stack
+    this.toString = () => `${this.message}: ${JSON.stringify(this.action)}`
+  }
 }
+
+const throwIfNotFSA = action => {
+  if (isFSA(action)) return
+
+  throw new NonStandardAction(action)
+}
+
+// eslint-disable-next-line no-process-env
+const isProduction = process.env.NODE_ENV === 'production'
+const ensureIsFSA = isProduction ? identity : throwIfNotFSA
+
+export default (initialState, handlers) =>
+  (state = initialState, action) => {
+    ensureIsFSA(action)
+
+    return propOr(identity, action.type, handlers)(state, action)
+  }


### PR DESCRIPTION
Restore a feature from Zeal’s react-boilerplate project that checks actions for FSA-compliance (FSA = flux-standard-action).

As before, we don’t check in production.