### PR TITLE
Add a nullAction and export it

### DIFF
--- a/src/__tests__/createReducer-spec.js
+++ b/src/__tests__/createReducer-spec.js
@@ -1,27 +1,32 @@
 import createReducer, { NonStandardAction } from '../createReducer'
+import nullAction from '../nullAction'
 
 describe('createReducer', () => {
   const mockHandler = jest.fn()
-  const initialState = { candy: 10 }
-  const handlers = {
+  const reducer = createReducer({ candy: 10 }, {
     ['ACTION_MATCH']: mockHandler
-  }
-  const reducer = createReducer(initialState, handlers)
-  const state = reducer(undefined, { type: 'NULL_ACTION' })
+  })
+  const initialState = reducer(undefined, nullAction)
 
   test('the reducer returns unchanged state with no match', () => {
-    expect(reducer(state, { type: 'FOO' })).toEqual({ candy: 10 })
+    const state = initialState
+    const action = { type: 'NON_MATCHING' }
+    const newState = reducer(state, action)
+
+    expect(newState).toEqual(state)
   })
 
   test('the reducer calls the matched hander with state', () => {
+    const state = initialState
     const action = { type: 'ACTION_MATCH' }
 
     reducer(state, action)
 
-    expect(mockHandler).toBeCalledWith(state, action)
+    expect(mockHandler).toHaveBeenCalledWith(state, action)
   })
 
   test('the reducer checks for flux standard actions', () => {
+    const state = initialState
     const invalidAction = {}
 
     expect(

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -21,9 +21,10 @@ const throwIfNotFSA = action => {
 const isProduction = process.env.NODE_ENV === 'production'
 const ensureIsFSA = isProduction ? identity : throwIfNotFSA
 
-export default (initialState, handlers) =>
-  (state = initialState, action) => {
+export default function createReducer(initialState, handlers) {
+  return (state = initialState, action) => {
     ensureIsFSA(action)
 
     return propOr(identity, action.type, handlers)(state, action)
   }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export createActionTypes from './createActionTypes'
 export createReducer from './createReducer'
 export globalizeSelectors from './globalizeSelectors'
+export nullAction from './nullAction'

--- a/src/nullAction.js
+++ b/src/nullAction.js
@@ -1,0 +1,5 @@
+const nullAction = {
+  type: '__NULL_ACTION__'
+}
+
+export default nullAction


### PR DESCRIPTION
We were already using a null action in our `createReducer` spec; this just makes it a public export, as it is a handy utility when testing reducers.

Also:
* Turn `createReducer` back into a named function; that was inadvertently changed in #6.
* Refactor the `createReducer` spec to decouple them from state shape, and to follow a more standard pattern for reducer specs as discussed in [this blog post](http://randycoulman.com/blog/2016/09/13/encapsulating-the-redux-state-tree/).